### PR TITLE
Added quick fix using plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,9 @@
         "development": {
             "plugins": [
                 ["react-transform", {
-                    "transforms": [
-                        {
+                    "transforms": [{
+                            "transform": "react-transform-display-name"
+                        }, {
                             "transform": "react-transform-hmr",
                             "imports": ["react"],
                             "locals": ["module"]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "express": "^4.13.4",
     "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react-dom": "^0.14.7",
+    "react-transform-display-name": "^0.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.4.5",


### PR DESCRIPTION
Using `react-transform-display-name` plugin to correct display names in React Developer Tools.
